### PR TITLE
[FIX] Clipboard copy fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4015,6 +4015,14 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "copy-to-clipboard": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.2.0.tgz",
+      "integrity": "sha512-eOZERzvCmxS8HWzugj4Uxl8OJxa7T2k1Gi0X5qavwydHIfuSHq2dTD09LOg/XyGq4Zpb5IsR/2OJ5lbOegz78w==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "core-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
@@ -11994,6 +12002,15 @@
         "whatwg-fetch": "3.0.0"
       }
     },
+    "react-copy-to-clipboard": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.1.tgz",
+      "integrity": "sha512-ELKq31/E3zjFs5rDWNCfFL4NvNFQvGRoJdAKReD/rUPA+xxiLPQmZBZBvy2vgH7V0GE9isIQpT9WXbwIVErYdA==",
+      "requires": {
+        "copy-to-clipboard": "^3",
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-dev-utils": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-9.0.1.tgz",
@@ -14243,6 +14260,11 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "toidentifier": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "lodash.sample": "4.2.1",
     "react": "16.8.6",
+    "react-copy-to-clipboard": "5.0.1",
     "react-dom": "16.8.6",
     "react-router-dom": "5.0.1",
     "react-scripts": "3.0.1",

--- a/src/components/QuoteBubble/CopyButton.js
+++ b/src/components/QuoteBubble/CopyButton.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 
 import { CopyCards } from '../Icons';
 import HitboxBase from '../Hitbox';
@@ -11,16 +12,18 @@ const Hitbox = styled(HitboxBase)`
   right: 0;
 `;
 
-function CopyButton({ onCopy }) {
+function CopyButton({ valueToCopy }) {
   return (
-    <Hitbox onClick={onCopy}>
-      <CopyCards />
-    </Hitbox>
+    <CopyToClipboard text={valueToCopy}>
+      <Hitbox>
+        <CopyCards />
+      </Hitbox>
+    </CopyToClipboard>
   );
 }
 
 CopyButton.propTypes = {
-  onCopy: PropTypes.func.isRequired
+  valueToCopy: PropTypes.string.isRequired
 };
 
 export default CopyButton;

--- a/src/components/QuoteBubble/QuoteBubble.js
+++ b/src/components/QuoteBubble/QuoteBubble.js
@@ -10,20 +10,12 @@ import Quote from './Quote';
 
 const DEFAULT_QUOTE = "Daily in 5 minutes and I'm still not sure what to say...";
 
-function copyTextFromBubble(text) {
-  navigator.clipboard.writeText(text);
-}
-
 function QuoteBubble({ quote = DEFAULT_QUOTE, variant = SPEECH, noCopyToClipboard = false }) {
-  const onCopy = () => {
-    copyTextFromBubble(quote);
-  };
-
   return (
     <Wrapper>
       <Quote>{quote}</Quote>
       <SpeechBubble variant={variant} />
-      {!noCopyToClipboard && <CopyButton onCopy={onCopy} />}
+      {!noCopyToClipboard && <CopyButton valueToCopy={quote} />}
     </Wrapper>
   );
 }

--- a/src/components/QuoteBubble/__tests__/__snapshots__/QuoteBubble.test.js.snap
+++ b/src/components/QuoteBubble/__tests__/__snapshots__/QuoteBubble.test.js.snap
@@ -20,7 +20,7 @@ exports[`COMPONENT - QuoteBubble renders correct defaults when no props are prov
     variant="speech"
   />
   <CopyButton
-    onCopy={[Function]}
+    valueToCopy="Daily in 5 minutes and I'm still not sure what to say..."
   />
 </Wrapper>
 `;
@@ -45,7 +45,7 @@ exports[`COMPONENT - QuoteBubble renders custom quote 1`] = `
     variant="speech"
   />
   <CopyButton
-    onCopy={[Function]}
+    valueToCopy="Hello! I'm Taylor Swift!"
   />
 </Wrapper>
 `;


### PR DESCRIPTION
[FIX](https://digitalrig.atlassian.net/browse/DR-74) Clipboard copy fix

# Description 
`Navigator` API seems to be badly supported by various browsers, so we are forced to change the way how we handle copy event.
The most recommended way of copying next to `Navigator` API is `execCommand`. Although to make it possible in ReactJS we need to work on Refs, which is pretty uncomfortable in our functional codebase. Although there is a decent package [react-copy-to-clipboard](https://www.npmjs.com/package/react-copy-to-clipboard) (based on [copy-to-clipboard](https://www.npmjs.com/package/copy-to-clipboard)), that allows us to handle copy in more declarative way. I think that it is worth the separate `npm` package trade-off.