### PR TITLE
[FIX] Footer layout on mobile

### DIFF
--- a/src/components/Footer/Content.js
+++ b/src/components/Footer/Content.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+import media from '../../styles/media';
 import { spacingSmall, spacingMedium } from '../../styles/designTokens';
 import ContentBase from '../Content';
 
@@ -9,6 +10,11 @@ const Content = styled(ContentBase)`
   justify-content: center;
   padding: ${spacingSmall};
   padding-bottom: ${spacingMedium};
+
+  ${media.phone`
+    flex-direction: column;
+    align-items: center;
+  `};
 `;
 
 export default Content;


### PR DESCRIPTION
# [FIX] Footer layout on mobile
Improved functionality/look of footer's links on some mobile devices.

Before:
![Screenshot 2019-08-01 at 14 15 14](https://user-images.githubusercontent.com/20565536/62292625-1fd20700-b467-11e9-8e4a-39d200e84c22.png)
After:
![Screenshot 2019-08-01 at 14 16 06](https://user-images.githubusercontent.com/20565536/62292630-2496bb00-b467-11e9-9cd3-0af013268a63.png)
