### PR TITLE
[FIX] Body scroll lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "daily-routine",
-  "version": "0.6.0",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2670,6 +2670,11 @@
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
+    },
+    "body-scroll-lock": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-2.6.4.tgz",
+      "integrity": "sha512-NP08WsovlmxEoZP9pdlqrE+AhNaivlTrz9a0FF37BQsnOrpN48eNqivKkE7SYpM9N+YIPjsdVzfLAUQDBm6OQw=="
     },
     "bonjour": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "deploy": "node ./deploy.js"
   },
   "dependencies": {
+    "body-scroll-lock": "2.6.4",
     "focus-visible": "5.0.2",
     "lodash.includes": "4.3.0",
     "lodash.isempty": "4.4.0",

--- a/src/components/GlobalStyle/GlobalStyle.js
+++ b/src/components/GlobalStyle/GlobalStyle.js
@@ -17,7 +17,7 @@ const GlobalStyle = createGlobalStyle`
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    overflow-y: scroll;
+    overflow: auto;
     font-weight: ${fontWeightNormal};
     font-size: ${fontMedium};
     color: ${colorBlack};

--- a/src/hooks/__tests__/useLockBodyScroll.test.js
+++ b/src/hooks/__tests__/useLockBodyScroll.test.js
@@ -1,17 +1,20 @@
 import { renderHook } from '@testing-library/react-hooks';
+import * as bodyScrollLock from 'body-scroll-lock';
 
 import useLockBodyScroll from '../useLockBodyScroll';
 
 describe('HOOK - useLockBodyScroll', () => {
-  it("sets body overflow to 'auto' when falsy flag is passed", () => {
+  it("calls 'enableBodyScroll' when falsy flag is passed", () => {
+    const spy = jest.spyOn(bodyScrollLock, 'enableBodyScroll');
     renderHook(() => useLockBodyScroll(false));
 
-    expect(document.body.style.overflowY).toEqual('auto');
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  it("sets body overflow to 'hidden' when truthy flag is passed", () => {
+  it("calls 'disableBodyScroll' when truthy flag is passed", () => {
+    const spy = jest.spyOn(bodyScrollLock, 'disableBodyScroll');
     renderHook(() => useLockBodyScroll(true));
 
-    expect(document.body.style.overflowY).toEqual('hidden');
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/useLockBodyScroll.js
+++ b/src/hooks/useLockBodyScroll.js
@@ -2,20 +2,17 @@
 // Most of time state of component such as isVisible, isAnimating should be passed
 
 import { useLayoutEffect } from 'react';
-
-function setBodyScroll(overflow) {
-  document.body.style.overflowY = overflow;
-}
+import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
 
 function useLockBodyScroll(shouldLock = false) {
   useLayoutEffect(() => {
     if (shouldLock) {
-      setBodyScroll('hidden');
+      disableBodyScroll();
     } else {
-      setBodyScroll('auto');
+      enableBodyScroll();
     }
 
-    return () => setBodyScroll('auto');
+    return () => clearAllBodyScrollLocks();
   }, [shouldLock]);
 }
 


### PR DESCRIPTION
# [FIX] Body scroll lock

Previous solution was not locking scroll on some safari browsers.
Updated **useLockBodyScroll** hook to use **body-scroll-lock** lib under the hood.